### PR TITLE
Drop PHP 7 support

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3']
+        php: ['8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           composer install
       - name: Run PHP Coding Standards Fixer tool
         run: |
-          php ./vendor/bin/php-cs-fixer fix --dry-run --config=.php_cs.dist
+          php ./vendor/bin/php-cs-fixer fix --dry-run --config=.php-cs-fixer.dist.php
       - name: Run phpstan
         run: |
           php ./vendor/bin/phpstan analyse src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 vendor
 composer.lock
-/.php_cs.cache
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,23 +1,23 @@
 <?php
 
-$finder = \PhpCsFixer\Finder::create()->in('src')->in('test');
+$finder = (new PhpCsFixer\Finder())->in('src')->in('test');
 
-return \PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHP71Migration' => true,
+        '@PHP80Migration' => true,
+        '@PHP80Migration:risky' => true,
         '@DoctrineAnnotation' => true,
 
         // @Symfony code styles rules blacklisting:
         'method_chaining_indentation' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_trailing_comma_in_list_call' => false,
         'php_unit_fqcn_annotation' => false,
         'phpdoc_align' => false,
         'phpdoc_annotation_without_dot' => false,
         'phpdoc_indent' => false,
-        'phpdoc_inline_tag' => false,
+        'phpdoc_inline_tag_normalizer' => false,
         'phpdoc_no_access' => false,
         'phpdoc_no_alias_tag' => false,
         'phpdoc_no_empty_return' => false,
@@ -32,11 +32,10 @@ return \PhpCsFixer\Config::create()
         'phpdoc_trim' => false,
         'phpdoc_types' => false,
         'phpdoc_var_without_name' => false,
-        'silenced_deprecation_error' => false,
         'standardize_not_equals' => false,
 
         // @Symfony customised rules
-        'class_attributes_separation' => ['elements' => ['method', 'property']],
+        'class_attributes_separation' => ['elements' => ['method' => 'one', 'property' => 'one']],
         'concat_space' => ['spacing' => 'one'],
         'single_quote' => ['strings_containing_single_quote_chars' => true],
         'visibility_required' => ['elements' => ['property', 'method', 'const']],
@@ -61,7 +60,6 @@ return \PhpCsFixer\Config::create()
         'no_alternative_syntax' => true,
         'no_superfluous_elseif' => true,
         'ordered_imports' => true,
-        'PedroTroller/single_line_comment' => ['action' => 'collapsed'],
         'PedroTroller/forbidden_functions' => [
             'comment' => 'TO BE DELETED',
             'functions' => ['die', 'dump', 'exec', 'var_dump', 'var_export'],

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,17 @@
   "type": "library",
   "keywords": ["polyfill", "compatibility", "portable", "calendar"],
   "require": {
-    "php": "^7.1 || ^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.16",
+    "friendsofphp/php-cs-fixer": "^3.0",
     "pedrotroller/php-cs-custom-fixer": "^2.19",
-    "phpspec/phpspec": "^5.1 || ^6.1 || ^7.2",
-    "phpstan/phpstan": "^0.12.8",
-    "phpstan/phpstan-strict-rules": "^0.12.2",
+    "phpspec/phpspec": "^7.2",
+    "phpstan/phpstan": "^1.0",
+    "phpstan/phpstan-strict-rules": "^1.0",
     "pyrech/composer-changelogs": "^1.7",
     "roave/security-advisories": "dev-master",
-    "vimeo/psalm": "^4.26"
+    "vimeo/psalm": "^5.0"
   },
   "license": "MIT",
   "authors": [
@@ -48,7 +48,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "2.0-dev"
     }
   }
 }

--- a/src/Easter.php
+++ b/src/Easter.php
@@ -16,9 +16,9 @@ final class Easter
     /**
      * Return the timestamp of midnight on Easter of a given year (defaults to current year)
      */
-    public static function easter_date(int $year = null): int
+    public static function easter_date(?int $year = null): int
     {
-        if (!$year) {
+        if ($year === null) {
             $year = (int) date('Y');
         }
 
@@ -38,14 +38,14 @@ final class Easter
     /**
      * Return the number of days after March 21 that Easter falls on for a given year (defaults to current year)
      */
-    public static function easter_days(int $year = null): int
+    public static function easter_days(?int $year = null): int
     {
         return self::calEaster($year, false);
     }
 
-    private static function calEaster(int $year = null, bool $isEasterDate): int
+    private static function calEaster(?int $year, bool $isEasterDate): int
     {
-        if (!$year) {
+        if ($year === null) {
             $year = (int) date('Y');
         }
 

--- a/src/Gregor.php
+++ b/src/Gregor.php
@@ -42,16 +42,16 @@ class Gregor implements SDNConversions
         }
         /* Make $year always a positive number. */
         if ($year < 0) {
-            $year = $year + 4801;
+            $year += 4801;
         } else {
-            $year = $year + 4800;
+            $year += 4800;
         }
 
         /* Adjust the start of the $year. */
         if ($month > 2) {
-            $month = $month - 3;
+            $month -= 3;
         } else {
-            $month = $month + 9;
+            $month += 9;
             --$year;
         }
 

--- a/src/Jewish.php
+++ b/src/Jewish.php
@@ -73,7 +73,7 @@ final class Jewish implements SDNConversions
                 /* Find the end of the year. */
                 $moladHalakim += self::HALAKIM_PER_LUNAR_CYCLE * self::getMonthsInYear($metonicYear);
                 $moladDay += (int) ($moladHalakim / self::HALAKIM_PER_DAY);
-                $moladHalakim = $moladHalakim % self::HALAKIM_PER_DAY;
+                $moladHalakim %= self::HALAKIM_PER_DAY;
                 $tishri1After = self::tishri1(($metonicYear + 1) % 19, $moladDay, $moladHalakim);
 
                 $yearLength = $tishri1After - $tishri1;
@@ -250,11 +250,11 @@ final class Jewish implements SDNConversions
 
     private static function findStartOfYear(
         int $year,
-        int &$metonicCycle = null,
-        int &$metonicYear = null,
-        int &$moladDay = null,
-        int &$moladHalakim = null,
-        int &$tishri1 = null
+        ?int &$metonicCycle = null,
+        ?int &$metonicYear = null,
+        ?int &$moladDay = null,
+        ?int &$moladHalakim = null,
+        ?int &$tishri1 = null
     ): void {
         $metonicCycle = (int) (($year - 1) / 19);
         $metonicYear = ($year - 1) % 19;
@@ -262,7 +262,7 @@ final class Jewish implements SDNConversions
 
         $moladHalakim += self::HALAKIM_PER_LUNAR_CYCLE * self::$yearOffset[$metonicYear];
         $moladDay += (int) ($moladHalakim / self::HALAKIM_PER_DAY);
-        $moladHalakim = $moladHalakim % self::HALAKIM_PER_DAY;
+        $moladHalakim %= self::HALAKIM_PER_DAY;
 
         $tishri1 = self::tishri1($metonicYear, $moladDay, $moladHalakim);
     }
@@ -305,8 +305,11 @@ final class Jewish implements SDNConversions
         return $tishri1;
     }
 
-    private static function moladOfMetonicCycle(int $metonicCycle, &$moladDay = null, int &$moladHalakim = null): void
-    {
+    private static function moladOfMetonicCycle(
+        int $metonicCycle,
+        ?int &$moladDay = null,
+        ?int &$moladHalakim = null
+    ): void {
         /* Start with the time of the first molad after creation. */
         $r1 = self::NEW_MOON_OF_CREATION;
 

--- a/src/Julian.php
+++ b/src/Julian.php
@@ -42,9 +42,9 @@ final class Julian implements SDNConversions
         $year = 100 * $year + $julian;
 
         if ($month < 10) {
-            $month = $month + 3;
+            $month += 3;
         } else {
-            $month = $month - 9;
+            $month -= 9;
             ++$year;
         }
 
@@ -52,7 +52,7 @@ final class Julian implements SDNConversions
             --$year;
         }
 
-        return "${month}/${day}/${year}";
+        return "{$month}/{$day}/{$year}";
     }
 
     /**
@@ -114,16 +114,16 @@ final class Julian implements SDNConversions
         }
         /* Make $year always a positive number. */
         if ($year < 0) {
-            $year = $year + 4801;
+            $year += 4801;
         } else {
-            $year = $year + 4800;
+            $year += 4800;
         }
 
         /* Adjust the start of the $year. */
         if ($month > 2) {
-            $month = $month - 3;
+            $month -= 3;
         } else {
-            $month = $month + 9;
+            $month += 9;
             --$year;
         }
 

--- a/src/ValueError.php
+++ b/src/ValueError.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Roukmoute\Polyfill\Calendar;
 
-use Error;
-
-final class ValueError extends Error
+final class ValueError extends \Error
 {
 }

--- a/test/Spec/CalendarSpec.php
+++ b/test/Spec/CalendarSpec.php
@@ -10,12 +10,12 @@ use Roukmoute\Polyfill\Calendar\ValueError;
 
 class CalendarSpec extends ObjectBehavior
 {
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(Calendar::class);
     }
 
-    public function it_calculates_cal_to_jd()
+    public function it_calculates_cal_to_jd(): void
     {
         $this->cal_to_jd(Calendar::CAL_GREGORIAN, 8, 26, 74)->shouldReturn(1748326);
         $this->cal_to_jd(Calendar::CAL_JULIAN, 8, 26, 74)->shouldReturn(1748324);
@@ -23,7 +23,7 @@ class CalendarSpec extends ObjectBehavior
         $this->cal_to_jd(Calendar::CAL_FRENCH, 8, 26, 74)->shouldReturn(0);
     }
 
-    public function it_throws_an_exception_cal_to_jd_when_first_argument_calendar_is_negative()
+    public function it_throws_an_exception_cal_to_jd_when_first_argument_calendar_is_negative(): void
     {
         $this->shouldThrow(new ValueError('Argument #1 ($calendar) must be a valid calendar ID'))->duringCal_to_jd(-1, 8, 26, 74);
     }

--- a/test/Spec/EasterSpec.php
+++ b/test/Spec/EasterSpec.php
@@ -10,52 +10,52 @@ use Roukmoute\Polyfill\Calendar\ValueError;
 
 class EasterSpec extends ObjectBehavior
 {
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(Easter::class);
     }
 
-    public function it_calculates_easter_date_for_year_2000()
+    public function it_calculates_easter_date_for_year_2000(): void
     {
         $this->easter_date(2000)->shouldReturn(956448000);
     }
 
-    public function it_calculates_easter_date_for_year_2001()
+    public function it_calculates_easter_date_for_year_2001(): void
     {
         $this->easter_date(2001)->shouldReturn(987292800);
     }
 
-    public function it_calculates_easter_date_for_year_2002()
+    public function it_calculates_easter_date_for_year_2002(): void
     {
         $this->easter_date(2002)->shouldReturn(1017532800);
     }
 
-    public function it_throws_an_exception_when_year_is_before_1970()
+    public function it_throws_an_exception_when_year_is_before_1970(): void
     {
         $this->shouldThrow(ValueError::class)->during('easter_date', [1969]);
     }
 
-    public function it_throws_an_exception_when_year_is_after_2037()
+    public function it_throws_an_exception_when_year_is_after_2037(): void
     {
         $this->shouldThrow(ValueError::class)->during('easter_date', [2038]);
     }
 
-    public function it_calculates_easter_days_for_year_1999()
+    public function it_calculates_easter_days_for_year_1999(): void
     {
         $this->easter_days(1999)->shouldReturn(14);
     }
 
-    public function it_calculates_easter_days_for_year_1492()
+    public function it_calculates_easter_days_for_year_1492(): void
     {
         $this->easter_days(1492)->shouldReturn(32);
     }
 
-    public function it_calculates_easter_days_for_year_1913()
+    public function it_calculates_easter_days_for_year_1913(): void
     {
         $this->easter_days(1913)->shouldReturn(2);
     }
 
-    public function it_calculates_easter_days_for_year_2025()
+    public function it_calculates_easter_days_for_year_2025(): void
     {
         $this->easter_days(2025)->shouldReturn(30);
     }

--- a/test/Spec/JewishSpec.php
+++ b/test/Spec/JewishSpec.php
@@ -9,12 +9,12 @@ use Roukmoute\Polyfill\Calendar\Jewish;
 
 class JewishSpec extends ObjectBehavior
 {
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(Jewish::class);
     }
 
-    public function it_calculates_julian_day_count_from_jewish_date()
+    public function it_calculates_julian_day_count_from_jewish_date(): void
     {
         $this->jewishtojd(-1, -1, -1)->shouldReturn(0);
         $this->jewishtojd(0, 0, 0)->shouldReturn(0);

--- a/test/Spec/JulianSpec.php
+++ b/test/Spec/JulianSpec.php
@@ -9,12 +9,12 @@ use Roukmoute\Polyfill\Calendar\Julian;
 
 class JulianSpec extends ObjectBehavior
 {
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(Julian::class);
     }
 
-    public function it_calculates_gregorian_date_from_julian_day_count()
+    public function it_calculates_gregorian_date_from_julian_day_count(): void
     {
         $this->jdtogregorian(2458489)->shouldReturn('1/5/2019');
         $this->jdtogregorian(2458465)->shouldReturn('12/12/2018');
@@ -30,7 +30,7 @@ class JulianSpec extends ObjectBehavior
         $this->jdtogregorian(9536838867)->shouldReturn('0/0/0');
     }
 
-    public function it_calculates_julian_day_count_from_julian_calendar_date()
+    public function it_calculates_julian_day_count_from_julian_calendar_date(): void
     {
         $this->juliantojd(0, 0, 0)->shouldReturn(0);
         $this->juliantojd(1, 1, 1582)->shouldReturn(2298884);


### PR DESCRIPTION
## Summary
- Remove support for PHP 7.x, now requires PHP 8.0+
- Update CI test matrix to PHP 8.0, 8.1, 8.2, 8.3, 8.4
- Upgrade dev dependencies for PHP 8 compatibility
- Migrate from php-cs-fixer v2 to v3

## Changes
- `composer.json`: PHP ^8.0, updated dev dependencies
- `.github/workflows/test.yml`: PHP 8.x matrix only
- `.github/workflows/linter.yml`: PHP 8.3 for linting
- `.php_cs.dist` → `.php-cs-fixer.dist.php`: v3 config format
- `.gitignore`: Updated cache file name