### PR TITLE
Fix CI badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Calendar Polyfill ![CI](https://github.com/roukmoute/polyfill-calendar/workflows/CI/badge.svg)
+# Calendar Polyfill ![Tests](https://github.com/roukmoute/polyfill-calendar/workflows/Tests/badge.svg)
 
 This project backports features found in the calendar extension.  
 It is intended to be used when calendar extension is not enabled.


### PR DESCRIPTION
## Summary
- Updates the badge URL from `workflows/CI/badge.svg` to `workflows/Tests/badge.svg`
- The "CI" workflow doesn't exist; the actual workflow is named "Tests"

Closes #25