### PR TITLE
Implement unixtojd

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently, functions available are:
 - [`jdtounix`](https://www.php.net/manual/en/function.jdtounix.php) — Convert Julian Day to Unix timestamp
 - [`jewishtojd`](https://www.php.net/manual/en/function.jewishtojd.php) — Converts a date in the Jewish Calendar to Julian Day Count
 - [`juliantojd`](https://www.php.net/manual/en/function.juliantojd.php) — Converts a Julian Calendar date to Julian Day Count
+- [`unixtojd`](https://www.php.net/manual/en/function.unixtojd.php) — Convert Unix timestamp to Julian Day
 
 ## Usage
 

--- a/runtime/bootstrap.php
+++ b/runtime/bootstrap.php
@@ -85,3 +85,10 @@ if (!function_exists('jdtounix')) {
         return Calendar::jdtounix($julian_day);
     }
 }
+
+if (!function_exists('unixtojd')) {
+    function unixtojd(?int $timestamp = null): int
+    {
+        return Calendar::unixtojd($timestamp);
+    }
+}

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -125,6 +125,24 @@ final class Calendar
         return ($julian_day - 2440588) * 86400;
     }
 
+    /**
+     * Convert Unix timestamp to Julian Day.
+     *
+     * @see https://www.php.net/manual/en/function.unixtojd.php
+     */
+    public static function unixtojd(?int $timestamp = null): int
+    {
+        if ($timestamp === null) {
+            $timestamp = time();
+        }
+
+        if ($timestamp < 0) {
+            throw new ValueError('unixtojd(): Argument #1 ($timestamp) must be greater than or equal to 0');
+        }
+
+        return (int) ($timestamp / 86400) + 2440588;
+    }
+
     private static function getMaxJulianDay(): int
     {
         return \PHP_INT_SIZE === 8 ? 106751993607888 : 2465443;

--- a/test/Spec/CalendarSpec.php
+++ b/test/Spec/CalendarSpec.php
@@ -200,4 +200,39 @@ class CalendarSpec extends ObjectBehavior
             ->duringJdtounix($maxJd + 1)
         ;
     }
+
+    /**
+     * Test cases from PHP source: ext/calendar/tests/unixtojd.phpt
+     */
+    public function it_converts_unix_timestamp_to_julian_day(): void
+    {
+        /* unixtojd(40000) = 2440588 (still on day 1 of Unix epoch) */
+        $this->unixtojd(40000)->shouldReturn(2440588);
+
+        /* unixtojd(1000000000) = 2452162 (2001-09-09) */
+        $this->unixtojd(1000000000)->shouldReturn(2452162);
+
+        /* unixtojd(1152459009) = 2453926 (2006-07-09) */
+        $this->unixtojd(1152459009)->shouldReturn(2453926);
+    }
+
+    public function it_converts_current_time_when_no_argument_given(): void
+    {
+        /* unixtojd() with no argument should return current JD */
+        $expected = (int) (time() / 86400) + 2440588;
+        $this->unixtojd()->shouldReturn($expected);
+
+        /* unixtojd(null) should also return current JD */
+        $this->unixtojd(null)->shouldReturn($expected);
+    }
+
+    /**
+     * Test case from PHP source: ext/calendar/tests/unixtojd_error1.phpt
+     */
+    public function it_throws_an_exception_for_negative_timestamp(): void
+    {
+        $this->shouldThrow(new ValueError('unixtojd(): Argument #1 ($timestamp) must be greater than or equal to 0'))
+            ->duringUnixtojd(-1)
+        ;
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `unixtojd()` function to convert Unix timestamp to Julian Day number
- Uses current time when no argument (or `null`) is provided
- Throws `ValueError` for negative timestamps

## Test plan
- [ ] CI tests pass (PHPSpec)
- [ ] Static analysis passes (PHPStan, Psalm)
- [ ] Code style check passes (PHP CS Fixer)

Closes #22