### PR TITLE
Implement jdtojulian

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently, functions available are:
 - [`gregoriantojd`](https://www.php.net/manual/en/function.gregoriantojd.php) — Converts a Gregorian date to Julian Day Count
 - [`jdtogregorian`](https://www.php.net/manual/en/function.jdtogregorian.php) — Converts Julian Day Count to Gregorian date
 - [`jdtojewish`](https://www.php.net/manual/en/function.jdtojewish.php) — Converts a Julian Day Count to the Jewish Calendar
+- [`jdtojulian`](https://www.php.net/manual/en/function.jdtojulian.php) — Converts a Julian Day Count to Julian Calendar Date
 - [`jdtounix`](https://www.php.net/manual/en/function.jdtounix.php) — Convert Julian Day to Unix timestamp
 - [`jewishtojd`](https://www.php.net/manual/en/function.jewishtojd.php) — Converts a date in the Jewish Calendar to Julian Day Count
 - [`juliantojd`](https://www.php.net/manual/en/function.juliantojd.php) — Converts a Julian Calendar date to Julian Day Count

--- a/runtime/bootstrap.php
+++ b/runtime/bootstrap.php
@@ -30,6 +30,13 @@ if (!function_exists('jdtogregorian')) {
     }
 }
 
+if (!function_exists('jdtojulian')) {
+    function jdtojulian(int $julian_day): string
+    {
+        return Julian::jdtojulian($julian_day);
+    }
+}
+
 if (!function_exists('jdtojewish')) {
     function jdtojewish(int $julian_day, bool $hebrew = false, int $flags = 0): string
     {

--- a/src/Julian.php
+++ b/src/Julian.php
@@ -56,6 +56,40 @@ final class Julian implements SDNConversions
     }
 
     /**
+     * Converts a Julian Day Count to a Julian Calendar Date.
+     *
+     * @see https://www.php.net/manual/en/function.jdtojulian.php
+     */
+    public static function jdtojulian(int $julian_day): string
+    {
+        if ($julian_day <= 0) {
+            return '0/0/0';
+        }
+
+        $temp = ($julian_day + self::JULIAN_SDN_OFFSET) * 4 - 1;
+        $year = (int) ($temp / self::DAYS_PER_4_YEARS);
+        $dayOfYear = (int) (($temp % self::DAYS_PER_4_YEARS) / 4) + 1;
+
+        $temp = $dayOfYear * 5 - 3;
+        $month = (int) ($temp / self::DAYS_PER_5_MONTHS);
+        $day = (int) (($temp % self::DAYS_PER_5_MONTHS) / 5) + 1;
+
+        if ($month < 10) {
+            $month += 3;
+        } else {
+            $month -= 9;
+            ++$year;
+        }
+
+        $year -= 4800;
+        if ($year <= 0) {
+            --$year;
+        }
+
+        return "{$month}/{$day}/{$year}";
+    }
+
+    /**
      * @author Scott E. Lee
      * @see https://github.com/php/php-src/blob/5b01c4863fe9e4bc2702b2bbf66d292d23001a18/ext/calendar/julian.c
      */

--- a/test/Spec/JulianSpec.php
+++ b/test/Spec/JulianSpec.php
@@ -38,4 +38,17 @@ class JulianSpec extends ObjectBehavior
         $this->juliantojd(1, 1, -4713)->shouldReturn(0);
         $this->juliantojd(12, 25, 2019)->shouldReturn(2458856);
     }
+
+    /**
+     * Test cases from PHP source: ext/calendar/tests/jdtojulian.phpt
+     */
+    public function it_calculates_julian_calendar_date_from_julian_day_count(): void
+    {
+        $this->jdtojulian(0)->shouldReturn('0/0/0');
+        $this->jdtojulian(1)->shouldReturn('1/2/-4713');
+        $this->jdtojulian(2298874)->shouldReturn('12/22/1581');
+        $this->jdtojulian(2299151)->shouldReturn('9/25/1582');
+        $this->jdtojulian(2440588)->shouldReturn('12/19/1969');
+        $this->jdtojulian(2816423)->shouldReturn('12/12/2998');
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `jdtojulian()` function to convert Julian Day Count to Julian Calendar Date
- Returns date string in format "month/day/year"
- Returns "0/0/0" for invalid input (JD <= 0)

## Test plan
- [ ] CI tests pass (PHPSpec)
- [ ] Static analysis passes (PHPStan, Psalm)
- [ ] Code style check passes (PHP CS Fixer)

Closes #20