### PR TITLE
Implement jdtofrench

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently, functions available are:
 - [`easter_days`](https://www.php.net/manual/en/function.easter-days.php) — Get number of days after March 21 on which Easter falls for a given year
 - [`frenchtojd`](https://www.php.net/manual/en/function.frenchtojd.php) — Converts a date from the French Republican Calendar to a Julian Day Count
 - [`gregoriantojd`](https://www.php.net/manual/en/function.gregoriantojd.php) — Converts a Gregorian date to Julian Day Count
+- [`jdtofrench`](https://www.php.net/manual/en/function.jdtofrench.php) — Converts a Julian Day Count to French Republican Calendar Date
 - [`jdtogregorian`](https://www.php.net/manual/en/function.jdtogregorian.php) — Converts Julian Day Count to Gregorian date
 - [`jdtojewish`](https://www.php.net/manual/en/function.jdtojewish.php) — Converts a Julian Day Count to the Jewish Calendar
 - [`jdtojulian`](https://www.php.net/manual/en/function.jdtojulian.php) — Converts a Julian Day Count to Julian Calendar Date

--- a/runtime/bootstrap.php
+++ b/runtime/bootstrap.php
@@ -86,6 +86,13 @@ if (!function_exists('frenchtojd')) {
     }
 }
 
+if (!function_exists('jdtofrench')) {
+    function jdtofrench(int $julian_day): string
+    {
+        return French::jdtofrench($julian_day);
+    }
+}
+
 if (!function_exists('jdtounix')) {
     function jdtounix(int $julian_day): int
     {

--- a/src/French.php
+++ b/src/French.php
@@ -26,6 +26,29 @@ class French implements SDNConversions
     }
 
     /**
+     * Converts a Julian Day Count to French Republican Calendar Date.
+     *
+     * @see https://www.php.net/manual/en/function.jdtofrench.php
+     */
+    public static function jdtofrench(int $julian_day): string
+    {
+        /* French Republican calendar valid range: year 1-14 */
+        /* First valid: JD 2375840 (1/1/1), Last valid: JD 2380952 (13/5/14) */
+        if ($julian_day < 2375840 || $julian_day > 2380952) {
+            return '0/0/0';
+        }
+
+        $temp = ($julian_day - self::FRENCH_SDN_OFFSET) * 4 - 1;
+        $year = (int) ($temp / self::DAYS_PER_4_YEARS);
+        $dayOfYear = (int) (($temp % self::DAYS_PER_4_YEARS) / 4);
+
+        $month = (int) ($dayOfYear / self::DAYS_PER_MONTH) + 1;
+        $day = ($dayOfYear % self::DAYS_PER_MONTH) + 1;
+
+        return "{$month}/{$day}/{$year}";
+    }
+
+    /**
      * Convert a French republican calendar date to a SDN.
      * {@inheritDoc}
      */

--- a/test/Spec/FrenchSpec.php
+++ b/test/Spec/FrenchSpec.php
@@ -60,4 +60,17 @@ class FrenchSpec extends ObjectBehavior
         /* Common dates */
         $this->frenchtojd(1, 1, 14)->shouldReturn(2380588);
     }
+
+    /**
+     * Test cases from PHP source: ext/calendar/tests/jdtofrench.phpt
+     */
+    public function it_calculates_french_republican_date_from_julian_day_count(): void
+    {
+        $this->jdtofrench(0)->shouldReturn('0/0/0');
+        $this->jdtofrench(2375840)->shouldReturn('1/1/1');
+        $this->jdtofrench(2375850)->shouldReturn('1/11/1');
+        $this->jdtofrench(2375940)->shouldReturn('4/11/1');
+        $this->jdtofrench(2376345)->shouldReturn('5/21/2');
+        $this->jdtofrench(2385940)->shouldReturn('0/0/0');
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `jdtofrench()` function to convert Julian Day Count to French Republican Calendar Date
- Returns date string in format "month/day/year"
- Returns "0/0/0" for dates outside valid range (JD 2375840-2380952, years 1-14)

## Test plan
- [ ] CI tests pass (PHPSpec)
- [ ] Static analysis passes (PHPStan, Psalm)
- [ ] Code style check passes (PHP CS Fixer)

Closes #19