### PR TITLE
Fix branch-alias and PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "keywords": ["polyfill", "compatibility", "portable", "calendar"],
   "require": {
-    "php": "^8.0"
+    "php": ">=8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.0",
@@ -48,7 +48,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "2.0-dev"
+      "dev-master": "1.1-dev"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Change branch-alias from `2.0-dev` to `1.1-dev` to match the current release versioning
- Change PHP requirement from `^8.0` to `>=8.0` for forward compatibility with future PHP versions

Closes #42